### PR TITLE
[commands] add `CustomDefault.converters` to allow implicit conversions

### DIFF
--- a/discord/ext/commands/__init__.py
+++ b/discord/ext/commands/__init__.py
@@ -18,3 +18,4 @@ from .help import *
 from .converter import *
 from .cooldowns import *
 from .cog import *
+from .default import CustomDefault

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -35,6 +35,7 @@ import discord
 from .errors import *
 from .cooldowns import Cooldown, BucketType, CooldownMapping
 from . import converter as converters
+from . import default as defaults
 from ._types import _BaseCommand
 from .cog import Cog
 
@@ -407,11 +408,24 @@ class Command(_BaseCommand):
     def _get_converter(self, param):
         converter = param.annotation
         if converter is param.empty:
-            if param.default is not param.empty:
+            if param.default is not param.empty and not issubclass(param.default, defaults.CustomDefault):
                 converter = str if param.default is None else type(param.default)
             else:
                 converter = str
         return converter
+
+    async def _resolve_default(self, ctx, param):
+        try:
+            if inspect.isclass(param.default) and issubclass(param.default, defaults.CustomDefault):
+                instance = param.default()
+                return await instance.default(ctx=ctx, param=param)
+            elif isinstance(param.default, defaults.CustomDefault):
+                return await param.default.default(ctx=ctx, param=param)
+        except CommandError as e:
+            raise e
+        except Exception as e:
+            raise ConversionError(param.default, e) from e
+        return param.default
 
     async def transform(self, ctx, param):
         required = param.default is param.empty
@@ -440,7 +454,7 @@ class Command(_BaseCommand):
                 if self._is_typing_optional(param.annotation):
                     return None
                 raise MissingRequiredArgument(param)
-            return param.default
+            return await self._resolve_default(ctx, param)
 
         previous = view.index
         if consume_rest_is_special:

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -410,6 +410,8 @@ class Command(_BaseCommand):
         if converter is param.empty:
             if param.default is not param.empty and not issubclass(param.default, defaults.CustomDefault):
                 converter = str if param.default is None else type(param.default)
+            elif issubclass(param.default, defaults.CustomDefault):
+                converter = typing.Union[param.default.converters]
             else:
                 converter = str
         return converter

--- a/discord/ext/commands/default.py
+++ b/discord/ext/commands/default.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-2019 Rapptz
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+"""
+
+from .errors import MissingRequiredArgument
+
+__all__ = (
+    'CustomDefault',
+    'Author',
+    'Channel',
+    'Guild',
+    'Call',
+)
+
+class CustomDefault:
+    """The base class of custom defaults that require the :class:`.Context`.
+
+    Classes that derive from this should override the :meth:`~.CustomDefault.default`
+    method to do its conversion logic. This method must be a coroutine.
+    """
+
+    async def default(self, ctx, param):
+        """|coro|
+
+        The method to override to do conversion logic.
+
+        If an error is found while converting, it is recommended to
+        raise a :exc:`.CommandError` derived exception as it will
+        properly propagate to the error handlers.
+
+        Parameters
+        -----------
+        ctx: :class:`.Context`
+            The invocation context that the argument is being used in.
+        """
+        raise NotImplementedError('Derived classes need to implement this.')
+
+
+class Author(CustomDefault):
+    """Default parameter which returns the author for this context."""
+
+    async def default(self, ctx, param):
+        return ctx.author
+
+class Channel(CustomDefault):
+    """Default parameter which returns the channel for this context."""
+
+    async def default(self, ctx, param):
+        return ctx.channel
+
+class Guild(CustomDefault):
+    """Default parameter which returns the guild for this context."""
+
+    async def default(self, ctx, param):
+        if ctx.guild:
+            return ctx.guild
+        raise MissingRequiredArgument(param)
+
+class Call(CustomDefault):
+    """Easy wrapper for lambdas/inline defaults."""
+
+    def __init__(self, callback):
+        self._callback = callback
+
+    async def default(self, ctx, param):
+        return self._callback(ctx, param)

--- a/discord/ext/commands/default.py
+++ b/discord/ext/commands/default.py
@@ -24,6 +24,8 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
 
+import discord
+
 from .errors import MissingRequiredArgument
 
 __all__ = (
@@ -37,9 +39,11 @@ __all__ = (
 class CustomDefault:
     """The base class of custom defaults that require the :class:`.Context`.
 
-    Classes that derive from this should override the :meth:`~.CustomDefault.default`
-    method to do its conversion logic. This method must be a coroutine.
+    Classes that derive from this should override the :attr:`~.CustomDefault.converters` attribute to specify
+    converters to use and the :meth:`~.CustomDefault.default` method to do its conversion logic.
+    This method must be a coroutine.
     """
+    converters = (str,)
 
     async def default(self, ctx, param):
         """|coro|
@@ -60,12 +64,14 @@ class CustomDefault:
 
 class Author(CustomDefault):
     """Default parameter which returns the author for this context."""
+    converters = (discord.Member, discord.User)
 
     async def default(self, ctx, param):
         return ctx.author
 
 class Channel(CustomDefault):
     """Default parameter which returns the channel for this context."""
+    converters = (discord.TextChannel,)
 
     async def default(self, ctx, param):
         return ctx.channel

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -585,6 +585,60 @@ handlers that allow us to do just that. First we decorate an error handler funct
 The first parameter of the error handler is the :class:`.Context` while the second one is an exception that is derived from
 :exc:`~ext.commands.CommandError`. A list of errors is found in the :ref:`ext_commands_api_errors` page of the documentation.
 
+
+Custom Defaults
+---------------
+
+Custom defaults allow us to specify :class:`.Context`-based defaults. Custom defaults are always classes which inherit from
+:class:`.CustomDefault`.
+
+The library provides some simple default implementations in the :module:`default` - :class:`default.Author`, :class:`default.Channel`,
+and :class:`default.Guild` returning the corresponding properties from the Context. These can be used along with Converters to
+simplify your individual commands. You can also use :class:`default.Call` to quickly wrap existing functions.
+
+A DefaultParam returning `None` is valid - if this should be an error, raise :class:`.MissingRequiredArgument`.
+
+.. code-block:: python3
+
+    class AnyImage(Converter):
+        """Find images associated with the message."""
+
+        async def convert(self, ctx, argument):
+            if argument.startswith("http://") or argument.startswith("https://"):
+                return argument
+
+            member = await UserMemberConverter().convert(ctx, argument)
+            if member:
+                return str(member.avatar_url_as(format="png"))
+
+            raise errors.BadArgument(f"{argument} isn't a member or url.")
+
+    class LastImage(CustomDefault):
+        """Default param which finds the last image in chat."""
+
+        async def default(self, ctx, param):
+            for attachment in message.attachments:
+                if attachment.proxy_url:
+                    return attachment.proxy_url
+            async for message in ctx.history(ctx, limit=100):
+                for embed in message.embeds:
+                    if embed.thumbnail and embed.thumbnail.proxy_url:
+                        return embed.thumbnail.proxy_url
+                for attachment in message.attachments:
+                    if attachment.proxy_url:
+                        return attachment.proxy_url
+
+            raise errors.MissingRequiredArgument(param)
+
+    @bot.command()
+    async def echo_image(ctx, *, image: Image = LastImage):
+        async with aiohttp.ClientSession() as sess:
+            async with sess.get(image) as resp:
+                resp.raise_for_status()
+                my_bytes = io.BytesIO(await resp.content.read())
+        await ctx.send(file=discord.File(name="your_image", fp=my_bytes))
+
+
 Checks
 -------
 

--- a/docs/ext/commands/commands.rst
+++ b/docs/ext/commands/commands.rst
@@ -615,6 +615,7 @@ A DefaultParam returning `None` is valid - if this should be an error, raise :cl
 
     class LastImage(CustomDefault):
         """Default param which finds the last image in chat."""
+        converters = (AnyImage,)
 
         async def default(self, ctx, param):
             for attachment in message.attachments:
@@ -631,7 +632,7 @@ A DefaultParam returning `None` is valid - if this should be an error, raise :cl
             raise errors.MissingRequiredArgument(param)
 
     @bot.command()
-    async def echo_image(ctx, *, image: Image = LastImage):
+    async def echo_image(ctx, *, image=LastImage):
         async with aiohttp.ClientSession() as sess:
             async with sess.get(image) as resp:
                 resp.raise_for_status()


### PR DESCRIPTION
### Summary
Quick enhancement. This basically moves annotations from arguments to the `CustomDefault` class. This adds consistency with `arg=True` where it'll implicitly use the `bool` converter. The `converters` attribute will be ignored in the case annotations are provided in the command signature, as with the `bool` example.

### Checklist
- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
